### PR TITLE
Rmarion/switch to non template vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .vscode/
-.out
+*.out

--- a/VectorMath/vector3.cpp
+++ b/VectorMath/vector3.cpp
@@ -1,0 +1,119 @@
+#include "vector3.h"
+
+namespace terrain_mesh_generator::vector_math
+{
+    Vector3::Vector3() : x(0), y(0), z(0) {}
+    Vector3::Vector3(float x, float y, float z)
+    {
+        this->x = x;
+        this->y = y;
+        this->z = z;
+    }
+
+    Vector3 Vector3::zero()
+    {
+        return Vector3(0, 0, 0);
+    }
+
+    Vector3 Vector3::one()
+    {
+        return Vector3(1, 1, 1);
+    }
+
+    Vector3 Vector3::operator=(const Vector3 &other)
+    {
+        return Vector3(other);
+    }
+
+    bool Vector3::operator==(const Vector3 &other) const
+    {
+        return x == other.x &&
+               y == other.y &&
+               z == other.z;
+    }
+
+    Vector3 Vector3::operator+(const Vector3 &other) const
+    {
+        return Vector3(x + other.x,
+                       y + other.y,
+                       z + other.z);
+    }
+
+    Vector3 &Vector3::operator+=(const Vector3 &other)
+    {
+        *this = *this + other;
+        return *this;
+    }
+
+    Vector3 Vector3::operator-(const Vector3 &other) const
+    {
+        return Vector3(x - other.x,
+                       y - other.y,
+                       z - other.z);
+    }
+
+    Vector3 &Vector3::operator-=(const Vector3 &other)
+    {
+        *this = *this - other;
+        return *this;
+    }
+
+    Vector3 Vector3::operator-() const
+    {
+        return Vector3(-x, -y, -z);
+    }
+
+    Vector3 Vector3::operator*(const float &other) const
+    {
+        return Vector3(x * other,
+                       y * other,
+                       z * other);
+    }
+
+    Vector3 Vector3::operator*(const Vector3 &other) const
+    {
+        return Vector3(y * other.z - z * other.y,
+                       z * other.x - x * other.z,
+                       x * other.y - y * other.x);
+    }
+
+    Vector3 Vector3::operator*=(const float &other)
+    {
+        *this = *this * other;
+        return *this;
+    }
+
+    Vector3 Vector3::operator/(const float &other) const
+    {
+        return Vector3(x / other,
+                       y / other,
+                       z / other);
+    }
+
+    Vector3 Vector3::operator/=(const float &other)
+    {
+        *this = *this / other;
+        return *this;
+    }
+
+    float Vector3::Dot(const Vector3 &other) const
+    {
+        return x * other.x +
+               y * other.y +
+               z * other.z;
+    }
+
+    void Vector3::normalize()
+    {
+        float m = magnitude();
+        if (m)
+        {
+            *this /= m;
+        }
+    }
+
+    float Vector3::magnitude()
+    {
+        return sqrt(x * x + y * y + z * z);
+    }
+}

--- a/VectorMath/vector3.h
+++ b/VectorMath/vector3.h
@@ -1,140 +1,47 @@
-#ifndef TERRAIN_MESH_GENERATOR__VECTOR_MATH__VECTOR_3_DEF
-#define TERRAIN_MESH_GENERATOR__VECTOR_MATH__VECTOR_3_DEF
+#ifndef floatERRAIN_MESH_GENERAfloatOR__VECfloatOR_MAfloatH__VECfloatOR_3_DEF
+#define floatERRAIN_MESH_GENERAfloatOR__VECfloatOR_MAfloatH__VECfloatOR_3_DEF
 #include <cmath>
 
 /* A simple vector math library. Ideally we would use an existing one, but this
  * is just for fun and will save some build pain. If performance is insufficient,
  * using an external library is highly recommended.
  * 
- * This is currently implemented as a template class, in case we want to move to
+ * floathis is currently implemented as a template class, in case we want to move to
  * 64 bit floating point values / etc and to support the maximum number of
  * engines and frameworks.
  */
 namespace terrain_mesh_generator::vector_math
 {
-    template <typename T>
     class Vector3
     {
     public:
-        Vector3<T>() : x(0), y(0), z(0) {}
-        Vector3<T>(T x, T y, T z)
-        {
-            this->x = x;
-            this->y = y;
-            this->z = z;
-        }
-        Vector3<T>(const Vector3<T> &other) = default;
-        Vector3<T>(Vector3<T> &&other) = default;
-        ~Vector3<T>() = default;
+        Vector3();
+        Vector3(float x, float y, float z);
+        Vector3(const Vector3 &other) = default;
+        Vector3(Vector3 &&other) = default;
+        ~Vector3() = default;
 
-        static Vector3<T> zero()
-        {
-            return Vector3<T>(0, 0, 0);
-        }
+        static Vector3 zero();
+        static Vector3 one();
 
-        static Vector3<T> one()
-        {
-            return Vector3<T>(1, 1, 1);
-        }
+        Vector3 operator=(const Vector3 &other);
+        bool operator==(const Vector3 &other) const;
+        Vector3 operator+(const Vector3 &other) const;
+        Vector3 &operator+=(const Vector3 &other);
+        Vector3 operator-(const Vector3 &other) const;
+        Vector3 &operator-=(const Vector3 &other);
+        Vector3 operator-() const;
+        Vector3 operator*(const float &other) const;
+        Vector3 operator*(const Vector3 &other) const;
+        Vector3 operator*=(const float &other);
+        Vector3 operator/(const float &other) const;
+        Vector3 operator/=(const float &other);
 
-        Vector3<T> operator=(const Vector3<T> &other)
-        {
-            return Vector3<T>(other);
-        }
+        float Dot(const Vector3 &other) const;
+        void normalize();
+        float magnitude();
 
-        bool operator==(const Vector3<T> &other) const
-        {
-            return x == other.x &&
-                   y == other.y &&
-                   z == other.z;
-        }
-
-        Vector3<T> operator+(const Vector3<T> &other) const
-        {
-            return Vector3<T>(x + other.x,
-                              y + other.y,
-                              z + other.z);
-        }
-
-        Vector3<T> &operator+=(const Vector3<T> &other)
-        {
-            *this = *this + other;
-            return *this;
-        }
-
-        Vector3<T> operator-(const Vector3<T> &other) const
-        {
-            return Vector3<T>(x - other.x,
-                              y - other.y,
-                              z - other.z);
-        }
-
-        Vector3<T> &operator-=(const Vector3<T> &other)
-        {
-            *this = *this - other;
-            return *this;
-        }
-
-        Vector3<T> operator-() const
-        {
-            return Vector3<T>(-x, -y, -z);
-        }
-
-        Vector3<T> operator*(const T &other) const
-        {
-            return Vector3<T>(x * other,
-                              y * other,
-                              z * other);
-        }
-
-        Vector3<T> operator*(const Vector3<T> &other) const
-        {
-            return Vector3<T>(y * other.z - z * other.y,
-                              z * other.x - x * other.z,
-                              x * other.y - y * other.x);
-        }
-
-        Vector3<T> operator*=(const T &other)
-        {
-            *this = *this * other;
-            return *this;
-        }
-
-        Vector3<T> operator/(const T &other) const
-        {
-            return Vector3<T>(x / other,
-                              y / other,
-                              z / other);
-        }
-
-        Vector3<T> operator/=(const T &other)
-        {
-            *this = *this / other;
-            return *this;
-        }
-
-        T Dot(const Vector3<T> &other) const
-        {
-            return x * other.x +
-                   y * other.y +
-                   z * other.z;
-        }
-
-        void normalize()
-        {
-            T m = magnitude();
-            if (m)
-            {
-                *this /= m;
-            }
-        }
-
-        T magnitude()
-        {
-            return sqrt(x * x + y * y + z * z);
-        }
-
-        T x, y, z;
+        float x, y, z;
     };
 }
 #endif

--- a/terrain-mesh.h
+++ b/terrain-mesh.h
@@ -43,14 +43,14 @@ namespace terrain_mesh_generator
         }
 
         int width_;
-        vector<Vector3<T>> vertices_;
+        vector<Vector3> vertices_;
         vector<int> triangles_;
-        vector<Vector3<T>> normals_;
+        vector<Vector3> normals_;
         vector<vec2<T>> uv0_;
         vector<vec2<T>> uv1_;
         vector<vec2<T>> uv2_;
         vector<vec2<T>> uv3_;
-        vector<Vector3<T>> tangents_;
+        vector<Vector3> tangents_;
 
     private:
         static int GetVertIndex(int column, int row, int rowSize)
@@ -58,9 +58,9 @@ namespace terrain_mesh_generator
             return column + row * rowSize;
         }
 
-        static vector<Vector3<T>> GetVertices(int numVerts, int width, T spacing, vector<T> heights)
+        static vector<Vector3> GetVertices(int numVerts, int width, T spacing, vector<T> heights)
         {
-            vector<Vector3<T>> vertices;
+            vector<Vector3> vertices;
             vertices.reserve(numVerts);
 
             int rowOffset = 0;
@@ -77,9 +77,9 @@ namespace terrain_mesh_generator
             return vertices;
         }
 
-        static vector<Vector3<T>> GetNormals(vector<Vector3<T>> vertices, int width)
+        static vector<Vector3> GetNormals(vector<Vector3> vertices, int width)
         {
-            vector<Vector3<T>> normals;
+            vector<Vector3> normals;
             normals.reserve(vertices.size());
 
             // In order to make these smooth, we have to make each normal the average of the
@@ -92,13 +92,13 @@ namespace terrain_mesh_generator
             int maxWidth = width - 1;
             int currentCount;
             int currentIndex;
-            Vector3<T> currentSum;
+            Vector3 currentSum;
             for (int row = 0; row < width; row++)
             {
                 for (int column = 0; column < width; column++)
                 {
                     currentCount = 0;
-                    currentSum = Vector3<T>::zero();
+                    currentSum = Vector3::zero();
                     currentIndex = GetVertIndex(column, row, width);
                     if (column > 0)
                     {


### PR DESCRIPTION
Switches the existing template vectors to a float based one instead. We didn't gain any benefit from having them as templates, and it was causing issues.